### PR TITLE
feat: Filter an image and returns the filtered image file

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,30 +13,29 @@ import {filterImageFromURL, deleteLocalFiles} from './util/util';
   // Use the body parser middleware for post requests
   app.use(bodyParser.json());
 
-  // @TODO1 IMPLEMENT A RESTFUL ENDPOINT
-  // GET /filteredimage?image_url={{URL}}
-  // endpoint to filter an image from a public url.
-  // IT SHOULD
-  //    1
-  //    1. validate the image_url query
-  //    2. call filterImageFromURL(image_url) to filter the image
-  //    3. send the resulting file in the response
-  //    4. deletes any files on the server on finish of the response
-  // QUERY PARAMATERS
-  //    image_url: URL of a publicly accessible image
-  // RETURNS
-  //   the filtered image file [!!TIP res.sendFile(filteredpath); might be useful]
+  
+ // filter Image endpoint
+ // Filter an image from a public url and returns the filtered image file to the user
+  app.get( "/filteredimage", async ( req, res ) => {
+    let { image_url } = req.query;
 
-  /**************************************************************************** */
+    if ( !image_url ) {
+      return res.status(400)
+                .send(`image url is required`);
+    }
 
-  //! END @TODO1
+    let filtered_path = await filterImageFromURL(image_url);
+    res.status(200).sendFile(filtered_path, () => {
+      
+       deleteLocalFiles([filtered_path]); 
+    });
+  });
   
   // Root Endpoint
   // Displays a simple message to the user
   app.get( "/", async ( req, res ) => {
     res.send("try GET /filteredimage?image_url={{}}")
   } );
-  
 
   // Start the Server
   app.listen( port, () => {


### PR DESCRIPTION
- Download, filter, and save the filtered image locally then returns the absolute path to the local image.

- Delete files on the local disk on finish of the response.